### PR TITLE
chore(helper): remove unnecessary assainment

### DIFF
--- a/lib/env_pull_request/test_helper.rb
+++ b/lib/env_pull_request/test_helper.rb
@@ -46,12 +46,12 @@ module EnvPullRequest
       #
       # @see Base#fetch_pull_request_id
       def restore_env_pull_request
-        @original_travis_pull_request ||= nil
-        @original_circle_pr_number ||= nil
-        @original_ghprb_pull_id ||= nil
-        ENV['TRAVIS_PULL_REQUEST'] = @original_travis_pull_request
-        ENV['CIRCLE_PR_NUMBER'] = @original_circle_pr_number
-        ENV['ghprbPullId'] = @original_ghprb_pull_id
+        env_pull_request_original_travis_pull_request = (defined?(@original_travis_pull_request) && @original_travis_pull_request) || nil
+        env_pull_request_original_circle_pr_number = (defined?(@original_circle_pr_number) && @original_circle_pr_number) || nil
+        env_pull_request_original_ghprb_pull_id = (defined?(@original_ghprb_pull_id) && @original_ghprb_pull_id) || nil
+        ENV['TRAVIS_PULL_REQUEST'] = env_pull_request_original_travis_pull_request
+        ENV['CIRCLE_PR_NUMBER'] = env_pull_request_original_circle_pr_number
+        ENV['ghprbPullId'] = env_pull_request_original_ghprb_pull_id
       end
   end
 end


### PR DESCRIPTION
`@original_travis_pull_request ||= nil` has side effect.
Remove unnecessary variable assignment.
